### PR TITLE
Code review for feedback only

### DIFF
--- a/api/main_endpoints/routes/Messages.js
+++ b/api/main_endpoints/routes/Messages.js
@@ -7,10 +7,11 @@ const {
 const { MAX_AMOUNT_OF_CONNECTIONS } = require('../../util/constants').MESSAGES_API;
 const express = require('express');
 const router = express.Router();
-const ChatMessage = require('../models/ChatMessage.js');
+const ChatMessage = require('../../main_endpoints/models/ChatMessage');
 const bodyParser = require('body-parser');
 const User = require('../models/User.js');
 const logger = require('../../util/logger');
+const client = require('prom-client');
 const { decodeToken, decodeTokenFromBodyOrQuery } = require('../util/token-functions.js');
 const { MetricsHandler, register } = require('../../util/metrics.js');
 

--- a/api/main_endpoints/routes/Messages.js
+++ b/api/main_endpoints/routes/Messages.js
@@ -7,10 +7,10 @@ const {
 const { MAX_AMOUNT_OF_CONNECTIONS } = require('../../util/constants').MESSAGES_API;
 const express = require('express');
 const router = express.Router();
+const ChatMessage = require('../models/ChatMessage.js');
 const bodyParser = require('body-parser');
 const User = require('../models/User.js');
 const logger = require('../../util/logger');
-const client = require('prom-client');
 const { decodeToken, decodeTokenFromBodyOrQuery } = require('../util/token-functions.js');
 const { MetricsHandler, register } = require('../../util/metrics.js');
 
@@ -23,7 +23,7 @@ const clients = {};
 const numberOfConnections = {};
 const lastMessageSent = {};
 
-const writeMessage = ((roomId, message, username) => {
+const writeMessage = async (roomId, message, username, userId) => {
 
   const messageObj = {
     timestamp: Date.now(),
@@ -35,6 +35,17 @@ const writeMessage = ((roomId, message, username) => {
     clients[roomId].forEach(res => res.write(`data: ${JSON.stringify(messageObj)}\n\n`));
   }
 
+  try {
+    const newMessage = new ChatMessage({
+      chatroomId: roomId,
+      userId: userId,
+      text: message,
+    });
+    await newMessage.save();
+  } catch (err) {
+    logger.error('Error saving chat message to MongoDB:', err);
+  }
+
   lastMessageSent[roomId] = JSON.stringify(messageObj);
 
   // increase the total messages sent counter
@@ -42,11 +53,15 @@ const writeMessage = ((roomId, message, username) => {
 
   // increase the total amount of messages sent per chatroom counter
   MetricsHandler.totalChatMessagesPerChatRoom.labels(roomId).inc();
-});
+};
 
 router.post('/send', async (req, res) => {
 
-  const {message, id} = req.body;
+  const {message, id: roomId} = req.body;
+  if (!message || !roomId) {
+    return res.status(BAD_REQUEST).send('Message and Room ID are required');
+  }
+
   const token = req.headers['authorization'];
   const apiKey = req.headers['x-api-key'];
 
@@ -54,7 +69,8 @@ router.post('/send', async (req, res) => {
   const required = [
     {value: token || apiKey, title: 'Token or API Key', },
     {value: message, title: 'Message', },
-    {value: id, title: 'Room ID', },
+    {value: roomId, title: 'Room ID' },
+
   ];
 
   const missingValue = required.find(({value}) => !value);
@@ -64,7 +80,8 @@ router.post('/send', async (req, res) => {
     return;
   }
 
-  let nameToUse = null;
+
+  let nameToUse, userId;
 
   if (apiKey) {
     try {
@@ -73,20 +90,22 @@ router.post('/send', async (req, res) => {
         return res.sendStatus(UNAUTHORIZED);
       }
       nameToUse = result.firstName;
+      userId = result._id;
     } catch (error) {
       logger.error('Error in /send User.findOne: ', error);
       return res.sendStatus(SERVER_ERROR);
     }
-  }
-
+  } else {
   // Assume user passed a non null/undefined token
-  const userObj = decodeToken(req);
-  if (!userObj) {
-    return res.sendStatus(UNAUTHORIZED);
+    const userObj = decodeToken(req);
+    if (!userObj) {
+      return res.sendStatus(UNAUTHORIZED);
+    }
+    nameToUse = userObj.firstName;
+    userId = userObj._id;
   }
-  nameToUse = userObj.firstName;
   try {
-    writeMessage(id, `${message}`, `${nameToUse}:`);
+    await writeMessage(roomId, message, `${nameToUse}:`, userId);
     return res.json({ status: 'Message sent' });
   } catch (error) {
     logger.error('Error in /send writeMessage: ', error);
@@ -95,42 +114,41 @@ router.post('/send', async (req, res) => {
 });
 
 router.get('/getLatestMessage', async (req, res) => {
-  const {apiKey, id} = req.query;
+  const { apiKey, id: roomId } = req.query;
 
-  const required = [
-    {value: apiKey, title: 'API Key'},
-    {value: id, title: 'Room ID'},
-  ];
-
-  const missingValue = required.find(({value}) => !value);
-
-  if (missingValue){
-    res.status(BAD_REQUEST).send(`You must specify a ${missingValue.title}`);
-    return;
+  if (!roomId) {
+    return res.status(BAD_REQUEST).send('You must specify a Room ID');
   }
 
   try {
-    User.findOne({ apiKey }, (error, result) => {
-      if (error) {
-        logger.error('/listen received an invalid API key: ', error);
-        res.sendStatus(SERVER_ERROR);
-        return;
-      }
+    const token = req.headers['authorization'];
 
-      if (!result) { // return unauthorized if no api key found
+    if (token) {
+      const userObj = decodeToken(req);
+      if (!userObj) {
         return res.sendStatus(UNAUTHORIZED);
       }
-
-      if (!lastMessageSent[id]) {
-        return res.status(OK).send('Room closed');
+      // token is valid; proceed
+    } else if (apiKey) {
+      const result = await User.findOne({ apiKey }).exec();
+      if (!result) {
+        return res.sendStatus(UNAUTHORIZED);
       }
+      // apiKey is valid; proceed
+    } else {
+      return res.status(BAD_REQUEST).send('You must specify a Token or API Key');
+    }
 
-      return res.status(OK).send(lastMessageSent[id]);
+    const messages = await ChatMessage
+      .find({ chatroomId: roomId })
+      .sort({ createdAt: -1 })
+      .limit(50)
+      .lean();
 
-    });
+    return res.status(OK).json(messages);
   } catch (error) {
-    logger.error('Error in /get: ', error);
-    res.sendStatus(SERVER_ERROR);
+    logger.error('Error in /getLatestMessage: ', error);
+    return res.sendStatus(SERVER_ERROR);
   }
 });
 
@@ -195,6 +213,25 @@ router.get('/listen', async (req, res) => {
       MetricsHandler.currentConnectionsOpen.labels(id).inc();
 
       clients[id].push(res);
+
+      // Immediately replay recent messages so UI shows history on reload
+      (async () => {
+        try {
+          const history = await ChatMessage.find({ chatroomId: id })
+            .sort({ createdAt: 1 }) // oldest -> newest
+            .limit(50)
+            .lean();
+          history.forEach(m => {
+            res.write(`data: ${JSON.stringify({
+              timestamp: new Date(m.createdAt || Date.now()).getTime(),
+              message: m.text,
+              username: ''
+            })}\n\n`);
+          });
+        } catch (e) {
+          logger.error('history hydration error', e);
+        }
+      })();
 
       req.on('close', () => {
         if(clients[id]){


### PR DESCRIPTION
Enable chat message persistence across reloads by hydrating history from MongoDB.

The previous setup only broadcasted live messages and did not load historical data from the database on page load or new SSE connections. This PR modifies `/getLatestMessage` to query MongoDB for recent messages and adds a history replay to the `/listen` SSE endpoint, ensuring messages appear after a reload.

---
<a href="https://cursor.com/background-agent?bcId=bc-97f18284-8b36-4855-857f-ee812e0632da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97f18284-8b36-4855-857f-ee812e0632da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

